### PR TITLE
Fix problems with columns in GMM results

### DIFF
--- a/src/algorithms/clustering/gmm.py
+++ b/src/algorithms/clustering/gmm.py
@@ -1,6 +1,7 @@
 from math import inf
 
 import numpy as np
+import pandas as pd
 from numpy.linalg import LinAlgError
 from PyQt5.QtWidgets import QMessageBox
 from scipy.stats import multivariate_normal
@@ -54,7 +55,11 @@ class GMM(Algorithm):
             error.setWindowTitle("Error")
             error.exec_()
             return
-        return self.get_cluster_labels(), self.mu_arr, self.sigma_arr
+        return (
+            self.get_cluster_labels(),
+            pd.DataFrame(self.mu_arr, columns=self.df.columns),
+            self.sigma_arr,
+        )
 
     def get_cluster_labels(self):
         return np.argmax(self.prob_matrix, axis=1)

--- a/src/widgets/results_widgets/gmm_results.py
+++ b/src/widgets/results_widgets/gmm_results.py
@@ -11,11 +11,11 @@ class GMMResultsWidget(AlgorithmResultsWidget):
     def __init__(self, df, labels, mean, sigma, options):
         super().__init__(df.select_dtypes(include=["number"]), options)
 
-        self.columns = self.data.columns
         self.labels = labels
         self.max_label = np.amax(self.labels) + 1
-        self.mean = pd.DataFrame(mean, columns=self.columns)
+        self.mean = mean
         self.sigma = sigma
+        self.columns = self.mean.columns
         self.layout = QHBoxLayout(self)
 
         # algorithm parameters


### PR DESCRIPTION
MR sets correct columns names to mu_arr (in algorithm there is imported_data, in gmm-result there is raw_data). MR removes the display of features that are not calculated in the algorithm because the program does not have sigma information for these columns.